### PR TITLE
Add possibility to define custom Python image for pip environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG PYTHON_PACKAGE_VERSION=3.9
-FROM python:$PYTHON_PACKAGE_VERSION as devpi
+ARG PYTHON_IMAGE=python:3.9
+FROM $PYTHON_IMAGE as devpi
 
 RUN pip install --quiet --upgrade devpi-server
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Build an image using Dockerfile present in current working directory
 ```bash
 podman build -t <image_name> .
 ```
-Alternatively you can specify version of Python packages to be pulled by providing build parameter `PYTHON_PACKAGE_VERSION`.
+Alternatively you can specify Python base image, used as environment detected by pip to pull dependencies for, by providing build parameter `PYTHON_IMAGE`.
 ```bash
-podman build -t <image_name> --build-arg PYTHON_PACKAGE_VERSION=3.8 .
+podman build -t <image_name> --build-arg PYTHON_IMAGE=pytorch/pytorch:1.11.0-cuda11.3-cudnn8-runtime .
 ```
 
 Run container instance using image created above by port forwarding container port `3141` to container host's port `3141` 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
N/A
Part of https://github.com/project-codeflare/codeflare-operator/issues/320

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Allow possibility to specify complete image tag as a source where pip install is executed. This approach makes sure that pip correctly detects environment and pull dependencies needed for this specific environment.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Build a devpi image based on readme.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->